### PR TITLE
Initial layout for backend of adding a log

### DIFF
--- a/app/src/main/java/cs486/splash/model/BowelLog.kt
+++ b/app/src/main/java/cs486/splash/model/BowelLog.kt
@@ -1,0 +1,33 @@
+package cs486.splash.model
+
+import androidx.annotation.ColorInt
+import java.util.Date
+
+/**
+ * A container class that represents each entry of a BowelLog
+ *
+ * @property id String                      the unique ID of each bowel log
+ * @property color Int                      the color integer of the bowel movement
+ * @property texture String                 the string indicating the texture of bowel movement
+ * @property timeStarted Date              the timestamp on which the bowel movement is started
+ * @property timeEnded Date               the timestamp on which the bowel movement is ended
+ * @property location String                the string describing where the bowel movement occurred
+ * @property symptoms SymptomTags           the symptoms experienced / noted for this bowel movement
+ * @property factors FactorTags             the factors suspected for this bowel movement
+ * @property timeCreated Date               the timestamp on which the bowel log is created
+ * @property timeModified Date              the timestamp on which the bowel log is modified
+ */
+class BowelLog(
+    var id: String,
+    @ColorInt
+    var color: Int = -1,
+    var texture: String = "",
+    val timeStarted: Date,
+    var timeEnded: Date,
+    var location: String,
+    var symptoms: SymptomTags,
+    var factors: FactorTags,
+    val timeCreated: Date,
+    var timeModified: Date
+) {
+}

--- a/app/src/main/java/cs486/splash/model/BowelLogRepo.kt
+++ b/app/src/main/java/cs486/splash/model/BowelLogRepo.kt
@@ -1,0 +1,17 @@
+package cs486.splash.model
+
+/**
+ * Temporarily the object that serves as storage holding the bowel logs. To be updated with
+ * communication to a backend server
+ */
+object  BowelLogRepo {
+    var bowelLogs = mutableListOf<BowelLog>()
+    fun fetchAllBowelLogs(): List<BowelLog> {
+        return bowelLogs
+    }
+
+    fun addNewBowelLog(bowelLog: BowelLog) : List<BowelLog>{
+        bowelLogs.add(bowelLog)
+        return bowelLogs
+    }
+}

--- a/app/src/main/java/cs486/splash/model/FactorTags.kt
+++ b/app/src/main/java/cs486/splash/model/FactorTags.kt
@@ -1,0 +1,13 @@
+package cs486.splash.model
+
+class FactorTags(
+    var workout : Boolean = false,
+    var water : Boolean = false,
+    var diet : Boolean = false,
+    var fiber : Boolean = false,
+    var other : String = ""
+) {
+    override fun toString(): String {
+        return "<workout: $workout, water: $water, diet: $diet, fiber: $fiber, other: '$other'>"
+    }
+}

--- a/app/src/main/java/cs486/splash/model/SymptomTags.kt
+++ b/app/src/main/java/cs486/splash/model/SymptomTags.kt
@@ -1,0 +1,15 @@
+package cs486.splash.model
+
+data class SymptomTags(
+    var bloating : Boolean = false,
+    var cramps : Boolean = false,
+    var pain : Boolean = false,
+    var nausea : Boolean = false,
+    var fatigue : Boolean = false,
+    var urgency : Boolean = false,
+    var other : String = ""
+) {
+    override fun toString(): String {
+        return "<bloating: $bloating, cramps: $cramps, pain: $pain, nausea: $nausea, fatigue: $fatigue, urgency: $urgency, other: '$other'>"
+    }
+}

--- a/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
+++ b/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
@@ -1,0 +1,33 @@
+package cs486.splash.viewmodels
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.concurrent.thread
+import cs486.splash.model.BowelLog
+import cs486.splash.model.BowelLogRepo
+
+data class BowelContentUiState(
+    val bowelLogs: List<BowelLog> = emptyList(),
+)
+
+class BowelLogViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(BowelContentUiState())
+    val uiState: StateFlow<BowelContentUiState> = _uiState.asStateFlow()
+
+    init {
+        thread {
+            _uiState.update { currentState ->
+                currentState.copy(bowelLogs = BowelLogRepo.fetchAllBowelLogs())
+            }
+        }
+    }
+
+    fun addNewBowelLog(bowelLog: BowelLog) {
+        _uiState.update { currentState ->
+            currentState.copy(bowelLogs = BowelLogRepo.addNewBowelLog(bowelLog))
+        }
+    }
+}


### PR DESCRIPTION
Lays out the initial data structures for a Bowel Log, as well as a structure to temporarily store Bowel Logs before we make data persistent. Adds the viewmodel for the adding a log screen, which has functionality to add logs to the temporary backend. 