### PR TITLE
Add editing and delete bowel log functionalities to backend.

### DIFF
--- a/app/src/main/java/cs486/splash/model/BowelLogRepo.kt
+++ b/app/src/main/java/cs486/splash/model/BowelLogRepo.kt
@@ -5,13 +5,39 @@ package cs486.splash.model
  * communication to a backend server
  */
 object  BowelLogRepo {
-    var bowelLogs = mutableListOf<BowelLog>()
-    fun fetchAllBowelLogs(): List<BowelLog> {
+    // Holds bowel logs, key is the id and value is the log
+    private var bowelLogs = HashMap<String, BowelLog>()
+
+    /**
+     * Returns the bowel logs
+     */
+    fun fetchAllBowelLogs(): Map<String, BowelLog> {
         return bowelLogs
     }
 
-    fun addNewBowelLog(bowelLog: BowelLog) : List<BowelLog>{
-        bowelLogs.add(bowelLog)
+    /**
+     * Returns the bowel logs after adding [bowelLog] to the repo
+     */
+    fun addNewBowelLog(bowelLog: BowelLog) : Map<String, BowelLog>{
+        // should add logic for checking that id is unique
+        // mb also add logic for assigning ID, as that should be done in the backend as oppose to frontend
+        bowelLogs[bowelLog.id] = bowelLog
+        return bowelLogs
+    }
+
+    /**
+     * Returns the bowel logs after editing [editedBowelLog]
+     */
+    fun editBowelLog(editedBowelLog: BowelLog) : Map<String, BowelLog>{
+        bowelLogs[editedBowelLog.id] = editedBowelLog
+        return bowelLogs
+    }
+
+    /**
+     * Returns the bowel logs after deleting the bowel log with id [bowelLogId]
+     */
+    fun deleteBowelLog(bowelLogId: String) : Map<String, BowelLog> {
+        bowelLogs.remove(bowelLogId)
         return bowelLogs
     }
 }

--- a/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
+++ b/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
@@ -9,10 +9,17 @@ import kotlin.concurrent.thread
 import cs486.splash.model.BowelLog
 import cs486.splash.model.BowelLogRepo
 
+
+/**
+ * Holds a immutable copy of the model's state
+ */
 data class BowelContentUiState(
-    val bowelLogs: List<BowelLog> = emptyList(),
+    val bowelLogs: Map<String, BowelLog> = mapOf<String, BowelLog>()
 )
 
+/**
+ * Layer that facilitates communication between View and Model
+ */
 class BowelLogViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(BowelContentUiState())
     val uiState: StateFlow<BowelContentUiState> = _uiState.asStateFlow()
@@ -25,9 +32,30 @@ class BowelLogViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Adds [bowelLog]
+     */
     fun addNewBowelLog(bowelLog: BowelLog) {
         _uiState.update { currentState ->
             currentState.copy(bowelLogs = BowelLogRepo.addNewBowelLog(bowelLog))
+        }
+    }
+
+    /**
+     * Edits [bowelLog]
+     */
+    fun editBowelLog(bowelLog: BowelLog) {
+        _uiState.update { currentState ->
+            currentState.copy(bowelLogs = BowelLogRepo.editBowelLog(bowelLog))
+        }
+    }
+
+    /**
+     * Deletes the bowel log with id [bowelLogId]
+     */
+    fun deleteBowelLog(bowelLogId: String) {
+        _uiState.update { currentState ->
+            currentState.copy(bowelLogs = BowelLogRepo.deleteBowelLog(bowelLogId))
         }
     }
 }


### PR DESCRIPTION
Resolving #9 and #10 
- Changes bowel logs are changed to be held in a map instead of list for ease of edit and delete.
- Added comments to model and viewModel.
- Discussion and changes need to be had about id assignment (see issue #29)