### PR TITLE
Link and adjust summary analysis backend and frontend

### DIFF
--- a/app/src/main/java/cs486/splash/shared/AnalysisData.kt
+++ b/app/src/main/java/cs486/splash/shared/AnalysisData.kt
@@ -2,7 +2,7 @@ package cs486.splash.shared
 
 import cs486.splash.models.BowelLog
 import java.util.Date
-import kotlin.math.round
+import kotlin.math.roundToInt
 
 /**
  * A class containing all analysis data
@@ -96,7 +96,7 @@ class AnalysisData {
      */
     fun getPercentageTextures() : Map<Texture, Pair<Int, String>> {
         return percentageTextures.mapValues {
-            Pair((round(it.value / 10)).toInt(), "%.2f".format(it.value) + "%")
+            Pair((it.value / 10).roundToInt(), "%.2f".format(it.value) + "%")
         }
     }
 
@@ -128,15 +128,15 @@ class AnalysisData {
     /**
      * Returns the percentages of logs with each symptom
      */
-    fun getPercentageSymptoms() : Map<String, Float> {
-        return percentageSymptoms
+    fun getPercentageSymptoms() : Map<String, String> {
+        return percentageSymptoms.mapValues { "%.2f".format(it.value) + "%" }
     }
 
     /**
      * Returns the percentages of logs with each factor
      */
-    fun getPercentageFactors() : Map<String, Float> {
-        return percentageFactors
+    fun getPercentageFactors() : Map<String, String> {
+        return percentageFactors.mapValues { "%.2f".format(it.value) + "%" }
     }
 
     /**

--- a/app/src/main/java/cs486/splash/shared/DateHelpers.kt
+++ b/app/src/main/java/cs486/splash/shared/DateHelpers.kt
@@ -41,3 +41,15 @@ fun getPastYearBeginDate(endDate : Date) : Date {
 
     return cal.time
 }
+
+fun getNumDays(startDate : Date, endDate: Date) : Int {
+    val diff: Long = endDate.time - startDate.time
+    val diffDays = diff / (24 * 60 * 60 * 1000) + 1
+    return diffDays.toInt()
+}
+
+fun formatHour(hourIndex : Int) : String {
+    var res = if (hourIndex == 0 || hourIndex == 12) "12:00" else (hourIndex % 12).toString() + ":00"
+    res += if (hourIndex < 12) "am" else "pm"
+    return res
+}

--- a/app/src/main/java/cs486/splash/ui/add/AddFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/add/AddFragment.kt
@@ -227,16 +227,16 @@ fun ColourPicker(
     }
 }
 
-val texturesDef: Map<String, Int> = mapOf(
-    "Solid" to R.drawable.poops_solid,
-    "Soft" to R.drawable.poops_soft,
-    "Pebbles" to R.drawable.poops_pebbles
+val texturesDef: Map<Texture, Int> = mapOf(
+    Texture.SOLID to R.drawable.poops_solid,
+    Texture.SOFT to R.drawable.poops_soft,
+    Texture.PEBBLES to R.drawable.poops_pebbles
 )
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun TexturePicker(
-    textures: Map<String, Int> = texturesDef,
+    textures: Map<Texture, Int> = texturesDef,
     onClick: (String) -> Unit
 ) {
     var texture by remember { mutableStateOf("Solid") }
@@ -255,13 +255,13 @@ fun TexturePicker(
                         shape = RoundedCornerShape(size = 8.dp)
                     )
                     .background(
-                        color = if (texture == entry.key) Color(0xFFEDE0D4) else Color(0x00EDE0D4),
+                        color = if (texture == entry.key.toString()) Color(0xFFEDE0D4) else Color(0x00EDE0D4),
                         shape = RoundedCornerShape(size = 8.dp)
                     )
                     .padding(8.dp)
                     .clickable {
-                        onClick(entry.key)
-                        texture = entry.key
+                        onClick(entry.key.toString())
+                        texture = entry.key.toString()
                     }
 
             ) {
@@ -269,7 +269,7 @@ fun TexturePicker(
                     painter = painterResource(id = entry.value),
                     contentDescription = null
                 )
-                Text(text = entry.key)
+                Text(text = entry.key.toString())
             }
         }
     }

--- a/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -276,7 +277,8 @@ fun FactorOrSymptomDisplay(
                 ) {
                     Text(
                         text = entry.key + ": " + entry.value,
-                        fontSize = 30.sp
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold
                     )
                 }
             }

--- a/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
@@ -94,6 +94,8 @@ class AnalysisFragment : Fragment() {
         // Default displays on initial load
         genTextureDisplay(binding)
         genColourDisplay(binding)
+        genSymptomsDisplay(binding)
+        genFactorsDisplay(binding)
 
         return root
     }

--- a/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.tabs.TabLayout
@@ -125,9 +126,9 @@ fun RoundedRectangle(
 fun genTextureDisplay(
     binding: FragmentAnalysisBinding,
     textureValues: Map<Texture, Pair<Int, String>> = mapOf(
-        Texture.SOLID to Pair(0, "0"),
-        Texture.SOFT to Pair(0, "0"),
-        Texture.PEBBLES to Pair(0, "0")
+        Texture.SOLID to Pair(0, "0.00%"),
+        Texture.SOFT to Pair(0, "0.00%"),
+        Texture.PEBBLES to Pair(0, "0.00%")
     )
 ) {
     binding.textureDisplay.apply {
@@ -150,6 +151,42 @@ fun genColourDisplay(
     }
 }
 
+fun genSymptomsDisplay(
+    binding: FragmentAnalysisBinding,
+    factors: Map<String, String> = mapOf(
+        "bloating" to "0.00%",
+        "cramps" to "0.00%",
+        "pain" to "0.00%",
+        "nausea" to "0.00%",
+        "fatigue" to "0.00%",
+        "urgency" to "0.00%"
+    )
+) {
+    binding.symptoms.apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            FactorOrSymptomDisplay(factors)
+        }
+    }
+}
+
+fun genFactorsDisplay(
+    binding: FragmentAnalysisBinding,
+    symptoms: Map<String, String> = mapOf(
+        "workout" to "0.00%",
+        "water" to "0.00%",
+        "diet" to "0.00%",
+        "fiber" to "0.00%"
+    )
+) {
+    binding.factors.apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            FactorOrSymptomDisplay(symptoms)
+        }
+    }
+}
+
 fun updateAnalysisDisplay(binding: FragmentAnalysisBinding, data: AnalysisData) {
     binding.poopTotal.text = data.getTimesTotal()
     binding.poopAvg.text = data.getAverageTimesPerDay()
@@ -158,6 +195,8 @@ fun updateAnalysisDisplay(binding: FragmentAnalysisBinding, data: AnalysisData) 
     binding.unusualColourNum.text = data.getNumUnusualColours()
     binding.averageDuration.text = data.getAverageDuration()
     binding.mostLoggedHours.text = data.getMostLogsHours()
+    genSymptomsDisplay(binding, data.getPercentageSymptoms())
+    genFactorsDisplay(binding, data.getPercentageFactors())
     binding.poopLocationNum.text = data.getNumLocations()
 }
 
@@ -203,7 +242,7 @@ fun TextureDisplay(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ColourDisplay(
-    mostCommonColours: List<Colour> = listOf()
+    mostCommonColours: List<Colour>
 ) {
     FlowRow(
         modifier = Modifier.padding(8.dp),
@@ -215,6 +254,32 @@ fun ColourDisplay(
                     .size(32.dp)
                     .background(Color(mostCommonColours[i].toColorLong()), CircleShape)
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun FactorOrSymptomDisplay(
+    factOrSymp : Map<String, String>
+) {
+    FlowRow(
+        modifier = Modifier.padding(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Column {
+            for (entry in factOrSymp) {
+                Row(
+                    modifier = Modifier.padding(top = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Text(
+                        text = entry.key + ": " + entry.value,
+                        fontSize = 30.sp
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/cs486/splash/ui/poopview/PoopViewFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/poopview/PoopViewFragment.kt
@@ -157,7 +157,7 @@ fun PoopViewContents(
         Row (modifier = Modifier.align(Alignment.CenterHorizontally)){
             Column {
                 Image(
-                    painter = painterResource(id = texturesDef[poop.texture.toString()] ?: R.drawable.poops_solid),
+                    painter = painterResource(id = texturesDef[poop.texture] ?: R.drawable.poops_solid),
                     contentDescription = null
                 )
                 Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
+++ b/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
@@ -65,6 +65,7 @@ class BowelLogViewModel : ViewModel() {
             }
             bowelLogs.value = bowelLogList
             bowelLogsByDate = orderBowelLogsByDate()
+            updateAnalysisData()
         })
     }
 

--- a/app/src/main/res/layout/fragment_analysis.xml
+++ b/app/src/main/res/layout/fragment_analysis.xml
@@ -21,7 +21,7 @@
         android:layout_marginEnd="8dp"
         android:textAlignment="center"
         android:textSize="20sp"
- />
+    />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabLayout"
@@ -30,6 +30,54 @@
         app:layout_constraintTop_toTopOf="parent">
     </com.google.android.material.tabs.TabLayout>
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|center"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/you_pooped_total_text1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="You pooped"
+            android:textSize="16sp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:layout_editor_absoluteY="61dp" />
+
+        <LinearLayout
+            android:layout_width="200dp"
+            android:layout_height="81dp"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/poop_total"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0"
+                android:textSize="30sp"
+                android:paddingStart="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/you_pooped_on_avg" />
+
+            <TextView
+                android:id="@+id/you_pooped_total_text2"
+                android:layout_width="250dp"
+                android:layout_height="22dp"
+                android:text=" times total"
+                android:textSize="16sp" />
+
+        </LinearLayout>
 
     <TextView
         android:id="@+id/you_pooped_on_avg"
@@ -37,6 +85,7 @@
         android:layout_height="wrap_content"
         android:text="You pooped an average of"
         android:textSize="16sp"
+        android:layout_marginTop="8dp"
         app:layout_constraintStart_toStartOf="parent"
         tools:layout_editor_absoluteY="61dp" />
 
@@ -49,8 +98,9 @@
                 android:id="@+id/poop_avg"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="1.0"
-                android:textSize="48sp"
+                android:text="0.00"
+                android:textSize="30sp"
+                android:paddingStart="10sp"
                 android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/you_pooped_on_avg" />
@@ -72,63 +122,129 @@
             android:id="@+id/poop_texture"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Most of your poops are "
+            android:text="Here is a breakdown of your poop textures"
             android:textSize="16sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/poop_avg" />
-
-        <TextView
-            android:id="@+id/poop_texture_value"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="solid."
-            android:textSize="16sp"
-            android:textStyle="bold"
-            app:layout_constraintStart_toEndOf="@+id/poop_texture"
-            app:layout_constraintTop_toTopOf="@+id/poop_texture" />
         </LinearLayout>
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/texture_display"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         app:layout_constraintTop_toTopOf="parent"
         tools:layout_editor_absoluteX="-7dp">
     </androidx.compose.ui.platform.ComposeView>
 
     <TextView
-        android:id="@+id/avg_colour_text"
+        android:id="@+id/most_common_colours_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="The average colour of your poop is:"
+        android:text="Your most common poop colours are"
         android:textSize="16sp"
         app:layout_constraintStart_toEndOf="@+id/poop_texture"
         app:layout_constraintTop_toTopOf="@+id/poop_texture" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/average_colour"
+        android:id="@+id/most_common_colours"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         app:layout_constraintTop_toTopOf="parent"
         tools:layout_editor_absoluteX="-7dp">
     </androidx.compose.ui.platform.ComposeView>
 
         <TextView
-            android:id="@+id/unusual_colour_text"
+            android:id="@+id/unusual_colour_text1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="You had two unusual coloured poops these week:"
+            android:text="You had "
             android:textSize="16sp"
             app:layout_constraintStart_toEndOf="@+id/poop_texture"
             app:layout_constraintTop_toTopOf="@+id/poop_texture" />
 
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/unusual_colour"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:layout_editor_absoluteX="-7dp">
-        </androidx.compose.ui.platform.ComposeView>
+        <LinearLayout
+            android:layout_width="250dp"
+            android:layout_height="81dp"
+            android:gravity="center_vertical">
+        <TextView
+            android:id="@+id/unusual_colour_num"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:textSize="30sp"
+            android:paddingStart="10sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/unusual_colour_text1" />
+
+        <TextView
+            android:id="@+id/unusual_colour_text2"
+            android:layout_width="500dp"
+            android:layout_height="22dp"
+            android:text=" unusually coloured poops"
+            android:textSize="16sp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/average_duration_text1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Your poops are on average"
+            android:textSize="16sp"
+            app:layout_constraintStart_toEndOf="@+id/poop_texture"
+            app:layout_constraintTop_toTopOf="@+id/poop_texture" />
+
+        <LinearLayout
+            android:layout_width="200dp"
+            android:layout_height="81dp"
+            android:gravity="center_vertical">
+            <TextView
+                android:id="@+id/average_duration"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0"
+                android:textSize="30sp"
+                android:paddingStart="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/average_duration_text1" />
+
+            <TextView
+                android:id="@+id/average_duration_text2"
+                android:layout_width="500dp"
+                android:layout_height="22dp"
+                android:text=" minutes"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/most_logged_hour_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="You pooped most at"
+            android:textSize="16sp"
+            app:layout_constraintStart_toEndOf="@+id/poop_texture"
+            app:layout_constraintTop_toTopOf="@+id/poop_texture" />
+
+        <LinearLayout
+            android:layout_width="500dp"
+            android:layout_height="71dp"
+            android:gravity="center_vertical">
+            <TextView
+                android:id="@+id/most_logged_hours"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="12:00am"
+                android:textSize="30sp"
+                android:paddingStart="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/most_logged_hour_text" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/you_pooped_location_text"
@@ -142,6 +258,7 @@
         <LinearLayout
             android:layout_width="200dp"
             android:layout_height="81dp"
+            android:layout_marginBottom="50dp"
             android:gravity="center_vertical">
 
             <TextView
@@ -149,11 +266,11 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="5"
-                android:textSize="48sp"
+                android:textSize="36dp"
+                android:paddingStart="10sp"
                 android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/you_pooped_on_avg" />
-
+                app:layout_constraintTop_toTopOf="@+id/you_pooped_location_text" />
 
             <TextView
                 android:id="@+id/different_locations"
@@ -163,7 +280,8 @@
                 android:textSize="16sp" />
 
         </LinearLayout>
-
+    </LinearLayout>
+    </ScrollView>
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_analysis.xml
+++ b/app/src/main/res/layout/fragment_analysis.xml
@@ -247,6 +247,44 @@
         </LinearLayout>
 
         <TextView
+            android:id="@+id/symptoms_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Here is a breakdown of your symptoms"
+            android:textSize="16sp"
+            app:layout_constraintStart_toEndOf="@+id/poop_texture"
+            app:layout_constraintTop_toTopOf="@+id/poop_texture" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/symptoms"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="-7dp">
+        </androidx.compose.ui.platform.ComposeView>
+
+        <TextView
+            android:id="@+id/factors_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Here is a breakdown of your factors"
+            android:textSize="16sp"
+            app:layout_constraintStart_toEndOf="@+id/poop_texture"
+            app:layout_constraintTop_toTopOf="@+id/poop_texture" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/factors"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="-7dp">
+        </androidx.compose.ui.platform.ComposeView>
+
+        <TextView
             android:id="@+id/you_pooped_location_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
**Changes to backend:**
- **(NEW)** total times per day (int) -> getter returns string
- Average times per day -> getter returns a 2 decimal precise float as a string
- Percentages of textures -> map with texture enums as keys and pairs of num blobs and percentage (int, string) as values
- Number of different locations -> getter returns string
- Number of logs with unusual colours -> getter returns string
- Average duration -> getter returns a 2 decimal precise float in minutes as a string
- What time has the most logs -> getter returns comma delimited string or "several hours of day" if more than 3 most logged hours
- Percentages of symptoms -> map value is a 2 decimal precise percentage float as a string
- Percentages of factors -> map value is a 2 decimal precise percentage float as a string

**Frontend:**
<img width="201" alt="1" src="https://github.com/amanda849/cs446-project/assets/59590407/595a1af7-c65e-4b6c-8f80-c0fee60c9755">
<img width="199" alt="2" src="https://github.com/amanda849/cs446-project/assets/59590407/578e7e9d-1c0a-4874-98b6-37613eb48121">
<img width="197" alt="3" src="https://github.com/amanda849/cs446-project/assets/59590407/2ee02b68-9e20-4422-828d-6ad57776a140">

**TODO:**
- NIT change text colour of composable text to match the rest of text
- Empty page when not enough data (minimum one log)
- Ensure all data loaded onCreate (default tab is weekly, so weekly data should be loaded, but currently is not) 
- Display fractions of icons for texture percentages