### PR TITLE
Display percentages of texture icons in summary analysis view

### DIFF
--- a/app/src/main/java/cs486/splash/shared/AnalysisData.kt
+++ b/app/src/main/java/cs486/splash/shared/AnalysisData.kt
@@ -95,9 +95,9 @@ class AnalysisData {
     /**
      * Returns the number of blobs and the percentages of logs with each texture
      */
-    fun getPercentageTextures() : Map<Texture, Pair<Int, String>> {
+    fun getPercentageTextures() : Map<Texture, Pair<Float, String>> {
         return percentageTextures.mapValues {
-            Pair((it.value / 10).roundToInt(), "%.2f".format(it.value) + "%")
+            Pair((it.value / 10), "%.2f".format(it.value) + "%")
         }
     }
 
@@ -147,6 +147,7 @@ class AnalysisData {
     fun update(startDate : Date, endDate : Date, logs : List<BowelLog>) {
         if (logs.isEmpty()) return
 
+        numUnusualColours = 0
 
         // Accumulators
         val timesPerDay : MutableList<Int> = mutableListOf(0)

--- a/app/src/main/java/cs486/splash/shared/AnalysisData.kt
+++ b/app/src/main/java/cs486/splash/shared/AnalysisData.kt
@@ -147,6 +147,7 @@ class AnalysisData {
     fun update(startDate : Date, endDate : Date, logs : List<BowelLog>) {
         if (logs.isEmpty()) return
 
+
         // Accumulators
         val timesPerDay : MutableList<Int> = mutableListOf(0)
         val colourCount : MutableMap<Colour, Int> = mutableMapOf(

--- a/app/src/main/java/cs486/splash/shared/Colour.kt
+++ b/app/src/main/java/cs486/splash/shared/Colour.kt
@@ -38,4 +38,4 @@ enum class Colour(@ColorInt private var c: Long) {
     }
 }
 
-val unusualColours : List<Colour> = listOf(Colour.PINKISH_BROWN)
+val unusualColours : List<Colour> = listOf(Colour.BLACK, Colour.GREEN)

--- a/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
+++ b/app/src/main/java/cs486/splash/ui/analysis/AnalysisFragment.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -23,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -129,14 +132,14 @@ fun RoundedRectangle(
 
 fun genTextureDisplay(
     binding: FragmentAnalysisBinding,
-    textureValues: Map<Texture, Pair<Int, String>> = mapOf(
-        Texture.PEBBLES to Pair(0, "0.00%"),
-        Texture.LUMPY to Pair(0, "0.00%"),
-        Texture.SAUSAGE to Pair(0, "0.00%"),
-        Texture.SMOOTH to Pair(0, "0.00%"),
-        Texture.BLOBS to Pair(0, "0.00%"),
-        Texture.MUSHY to Pair(0, "0.00%"),
-        Texture.LIQUID to Pair(0, "0.00%")
+    textureValues: Map<Texture, Pair<Float, String>> = mapOf(
+        Texture.PEBBLES to Pair(0f, "0.00%"),
+        Texture.LUMPY to Pair(0f, "0.00%"),
+        Texture.SAUSAGE to Pair(0f, "0.00%"),
+        Texture.SMOOTH to Pair(0f, "0.00%"),
+        Texture.BLOBS to Pair(0f, "0.00%"),
+        Texture.MUSHY to Pair(0f, "0.00%"),
+        Texture.LIQUID to Pair(0f, "0.00%")
     )
 ) {
     binding.textureDisplay.apply {
@@ -212,7 +215,7 @@ fun updateAnalysisDisplay(binding: FragmentAnalysisBinding, data: AnalysisData) 
 @Composable
 fun TextureDisplay(
     textures: Map<Texture, Int> = texturesDef,
-    textureValues: Map<Texture, Pair<Int, String>>
+    textureValues: Map<Texture, Pair<Float, String>>
 ) {
     var index = 0;
     FlowRow(
@@ -226,7 +229,9 @@ fun TextureDisplay(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.End
                 ) {
-                    for (i in 0 until textureValues[entry.key]!!.first) {
+                    val numBlobs = textureValues[entry.key]!!.first.toInt()
+                    val remainder = textureValues[entry.key]!!.first - numBlobs
+                    for (i in 0 until numBlobs) {
                         Column {
                             Image(
                                 painter = painterResource(id = entry.value),
@@ -237,6 +242,23 @@ fun TextureDisplay(
                             )
                         }
                     }
+                    if (remainder != 0f) {
+                        Log.d("Analysis", remainder.toString())
+                        val imgSize = (remainder * 32).toInt()
+                        Column {
+                            Image(
+                                painter = painterResource(id = entry.value),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .width(imgSize.dp)
+                                    .height(32.dp)
+                                    .padding(end = 3.dp),
+                                contentScale = ContentScale.FillHeight,
+                                alignment = Alignment.CenterStart
+                            )
+                        }
+                    }
+
                     Column(modifier = Modifier.padding(start = 2.dp)) {
                         Text(textureValues[entry.key]!!.second)
                     }

--- a/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
+++ b/app/src/main/java/cs486/splash/viewmodels/BowelLogViewModel.kt
@@ -66,7 +66,7 @@ class BowelLogViewModel : ViewModel() {
             }
             bowelLogs.value = bowelLogList
             bowelLogsByDate = orderBowelLogsByDate()
-            updateAnalysisData()
+            // updateAnalysisData()
         })
     }
 
@@ -81,7 +81,7 @@ class BowelLogViewModel : ViewModel() {
         bowelLogRepository.addNewBowelLog(bowelLog)
 
         // Update the analysis data when a new log is added
-        updateAnalysisData()
+        // updateAnalysisData()
     }
 
     /**
@@ -141,7 +141,7 @@ class BowelLogViewModel : ViewModel() {
         bowelLogRepository.deleteBowelLog(bowelLogId)
 
         // Update the analysis data when a log is deleted
-        updateAnalysisData()
+        // updateAnalysisData()
     }
 
     /**
@@ -208,7 +208,7 @@ class BowelLogViewModel : ViewModel() {
     /**
      * Recompute all analysis data for the past week, month and year
      */
-    private fun updateAnalysisData() {
+    fun updateAnalysisData() {
         // Get the current date one time for all time ranges
         val currDate = Date()
 


### PR DESCRIPTION
Display partial texture icons rather than rounding to whole icons.

![image](https://github.com/amanda849/cs446-project/assets/59590407/e8c90c36-21f9-4b29-afd0-9c6dcacb30e8)

Misc changes and fixes:
- Set unusual colours to green and black
- Fix numUnusualColours computation (reset to 0 each time analysis is recomputed)
